### PR TITLE
Fix finalMarkerLocation in Vision.java

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/Auto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/Auto.java
@@ -15,6 +15,12 @@ import org.firstinspires.ftc.teamcode.Robot;
  *
  * @see com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
  */
+
+//Tasks:
+// Deliver duck from carousel (10)
+//Deliver freight to hub (6)
+// - deliver freight to corresponding level of custom element (20)
+//Park in warehouse (10)
 @Autonomous(name = "Auto", group = "Concept")
 public class Auto extends LinearOpMode {
     ElapsedTime timer = new ElapsedTime();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoBlue.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoBlue.java
@@ -1,0 +1,52 @@
+package org.firstinspires.ftc.teamcode.Auto;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+import org.firstinspires.ftc.teamcode.Robot;
+
+
+/**
+ * Auto creates a robots and runs it in auto mode. This auto class is for when we are
+ * on the blue alliance.
+ *
+ * <p>Auto currently just initializes the Robot as Auto.runOpMode() is empty.</p>
+ *
+ * @see com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+ */
+
+//Tasks:
+// Deliver duck from carousel (10)
+//Deliver freight to hub (6)
+// - deliver freight to corresponding level of custom element (20)
+//Park in warehouse (10)
+@Autonomous(name = "Auto", group = "Concept")
+public class AutoBlue extends LinearOpMode {
+    ElapsedTime timer = new ElapsedTime();
+    Robot robot = new Robot(this, timer, true);
+
+
+    /** Override of runOpMode()
+     *
+     * <p>Please do not swallow the InterruptedException, as it is used in cases
+     * where the op mode needs to be terminated early.</p>
+     *
+     * @throws InterruptedException
+     *
+     * @see com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+     */
+    @Override
+    public void runOpMode() throws InterruptedException {
+
+        // TODO: Detect position for freight
+
+        // TODO: Move downwards and deliver duck
+
+        // TODO: Navigate to center of field and deliver freight
+
+        // TODO: Navigate to warehouse and park
+
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoBlue.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoBlue.java
@@ -22,7 +22,7 @@ import org.firstinspires.ftc.teamcode.Robot;
 //Deliver freight to hub (6)
 // - deliver freight to corresponding level of custom element (20)
 //Park in warehouse (10)
-@Autonomous(name = "Auto", group = "Concept")
+@Autonomous(name = "Auto Blue", group = "Concept")
 public class AutoBlue extends LinearOpMode {
     ElapsedTime timer = new ElapsedTime();
     Robot robot = new Robot(this, timer, true);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoRed.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoRed.java
@@ -1,0 +1,52 @@
+package org.firstinspires.ftc.teamcode.Auto;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+import org.firstinspires.ftc.teamcode.Robot;
+
+
+/**
+ * Auto creates a robots and runs it in auto mode. This auto class is for when we are
+ * on the red alliance.
+ *
+ * <p>Auto currently just initializes the Robot as Auto.runOpMode() is empty.</p>
+ *
+ * @see com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+ */
+
+//Tasks:
+// Deliver duck from carousel (10)
+//Deliver freight to hub (6)
+// - deliver freight to corresponding level of custom element (20)
+//Park in warehouse (10)
+@Autonomous(name = "Auto", group = "Concept")
+public class AutoRed extends LinearOpMode {
+    ElapsedTime timer = new ElapsedTime();
+    Robot robot = new Robot(this, timer, true);
+
+
+    /** Override of runOpMode()
+     *
+     * <p>Please do not swallow the InterruptedException, as it is used in cases
+     * where the op mode needs to be terminated early.</p>
+     *
+     * @throws InterruptedException
+     *
+     * @see com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+     */
+    @Override
+    public void runOpMode() throws InterruptedException {
+
+        // TODO: Detect position for freight
+
+        // TODO: Move downwards and deliver duck
+
+        // TODO: Navigate to center of field and deliver freight
+
+        // TODO: Navigate to warehouse and park
+
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoRed.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Auto/AutoRed.java
@@ -22,7 +22,7 @@ import org.firstinspires.ftc.teamcode.Robot;
 //Deliver freight to hub (6)
 // - deliver freight to corresponding level of custom element (20)
 //Park in warehouse (10)
-@Autonomous(name = "Auto", group = "Concept")
+@Autonomous(name = "Auto Red", group = "Concept")
 public class AutoRed extends LinearOpMode {
     ElapsedTime timer = new ElapsedTime();
     Robot robot = new Robot(this, timer, true);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Subsystems/Vision/Vision.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Subsystems/Vision/Vision.java
@@ -90,7 +90,7 @@ public class Vision extends Subsystem {
 
         telemetry.telemetry(4, "Detect Marker","Detecting Marker");
         DetectMarker detectMarkerRunnable = new DetectMarker(hardwareMap, robotCamera, telemetry);
-        MarkerLocation finalMarkerLocation = detectMarkerRunnable.DetectMarkerRun();
+        finalMarkerLocation = detectMarkerRunnable.DetectMarkerRun();
         telemetry.telemetry(3, "Detect Marker", "Detected Marker");
         telemetry.telemetry(2, "Vision Status", "Vision initialized");
     }


### PR DESCRIPTION
# Overview
This pull request makes it so that the marker location is available via `robot.vision.finalMarkerLocation`. 


# Info
**Related Task:** Auto, Vision
**Type (Update, Feature, Bug Fix, Hot Fix, etc.):** Bug Fix
**Description:**


**Additional Comments:**
